### PR TITLE
Tile upgrades

### DIFF
--- a/schemas/game.schema.json
+++ b/schemas/game.schema.json
@@ -222,6 +222,17 @@
         "additionalProperties": true
       }
     },
+    "upgrades": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      }
+    },
     "wip": { "type": "boolean" }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This PR adds an optional `upgrades` object to the games schema so that games can specify what tiles can upgrade to what other tiles.

Similar to the `tiles` object, `upgrades` is an object with tile ids as keys and an array of tile ids as the value to each key. A tile that can't be upgraded shouldn't be present in the upgrades object.