### PR TITLE
remove duplicate defs

### DIFF
--- a/schemas/game.schema.json
+++ b/schemas/game.schema.json
@@ -196,14 +196,9 @@
           "description": "Full cap is the default and doesn't need to be specified.",
           "enum": ["incremental"]
         },
-        "mustSellInBlocks": { "type": "boolean", "enum": [true] },
         "marketTokens": { "type": "integer", "minimum": 0 },
         "extraStationTokens": { "type": "integer", "mimimum": 1 },
         "mustSellInBlocks": { "type": "boolean" },
-        "capitalization": {
-          "type": "string",
-          "enum": ["full", "incremental"]
-        },
         "currency": {
           "description": "The currency format string must contain a # character",
           "type": "string",


### PR DESCRIPTION
Two elements were defined twice in this schema

Since `mustSellInBlocks` is a bool, seems like it doesn't need to be limited to `true` (since `false` conveys context that might be useful for documentation)

I presume `capitalization` is set to `full` by default in the code, as well